### PR TITLE
travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/ldx/ansible-packer.svg?branch=master)](https://travis-ci.org/ldx/ansible-packer)
-
 # packer
+
+[![Build Status](https://travis-ci.org/saucelabs-ansible/packer.svg?branch=master)](https://travis-ci.org/saucelabs-ansible/packer)
 
 Ansible role for installing [Packer](http://packer.io).
 


### PR DESCRIPTION
- fixed the URL for the travis-ci badge
- put repo title on top to match how the majority of repos on github display their badges
