### PR TITLE
newer versions: test-kitchen + kitchen-ansible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ rvm: 2.2
 services:
   - docker
 
-cache: bundler
-
-services:
-  - docker
-
 env:
   global:
     - KITCHEN_DRIVER=docker
@@ -30,4 +25,11 @@ before_script:
 
 script:
   - bundle exec kitchen test
+
+before_cache:
+  - rm -f ${HOME}/.cache/pip/log/debug.log
+
+cache:
+  - bundler
+  - pip
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 gem 'inspec'
-gem 'test-kitchen', '> 1.9.0'
+gem 'test-kitchen', '>= 1.9.2'
 gem 'kitchen-ansible', '>= 0.44.1'
 gem 'kitchen-vagrant'
 gem 'kitchen-inspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gem 'inspec'
 gem 'test-kitchen', '> 1.9.0'
-gem 'kitchen-ansible', '>= 0.43.0'
+gem 'kitchen-ansible', '>= 0.44.1'
 gem 'kitchen-vagrant'
 gem 'kitchen-inspec'
 gem 'kitchen-docker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       rubyzip (~> 1.1)
       thor (~> 0.19)
     json (1.8.3)
-    kitchen-ansible (0.43.1)
+    kitchen-ansible (0.44.1)
       librarian-ansible
       net-ssh (~> 3)
       test-kitchen (~> 1.4)
@@ -126,7 +126,7 @@ PLATFORMS
 
 DEPENDENCIES
   inspec
-  kitchen-ansible (>= 0.43.0)
+  kitchen-ansible (>= 0.44.1)
   kitchen-docker
   kitchen-inspec
   kitchen-vagrant

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.8.2)
-    mixlib-install (1.0.12)
+    mixlib-install (1.0.13)
       artifactory
       mixlib-shellout
       mixlib-versioning
@@ -99,7 +99,7 @@ GEM
     rubyzip (1.2.0)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    test-kitchen (1.9.1)
+    test-kitchen (1.9.2)
       mixlib-install (~> 1.0, >= 1.0.4)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -130,7 +130,7 @@ DEPENDENCIES
   kitchen-docker
   kitchen-inspec
   kitchen-vagrant
-  test-kitchen (> 1.9.0)
+  test-kitchen (>= 1.9.2)
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
- use newer version of kitchen-ansible
  - includes fix for https://github.com/neillturner/kitchen-ansible/issues/180
  - includes fix for https://github.com/neillturner/kitchen-ansible/issues/178
- use newer version of test-kitchen
  - includes fix for https://github.com/test-kitchen/test-kitchen/pull/1047
- added travis-ci pip caching
